### PR TITLE
Removed folders creation (will be done by "init")

### DIFF
--- a/impacthub-3/InstallImpacthub.sh
+++ b/impacthub-3/InstallImpacthub.sh
@@ -91,16 +91,6 @@ DAEMON=$GOBIN/$DAEMONNAME
 
 sleep 1
 
-mkdir /home/ixo/.ixod
-mkdir /home/ixo/.ixod/config
-
-cp /root/genesis/impacthub-3/genesis.json /home/ixo/.ixod/config/genesis.json
-
-chown -R ixo:ixo /home/ixo/.$DAEMONNAME
-chown -R ixo:ixo /home/ixo/.$DAEMONNAME/config/
-chown -R ixo:ixo /home/ixo/.$DAEMONNAME/config/genesis.json
-
-
 su $USERNAME <<EOSU
 
 $DAEMON init "ImpactHub node"


### PR DESCRIPTION
This is the error with cp/mkdir 
```
Error: genesis.json file already exists: /home/ixo/.ixod/config/genesis.json
Usage:
  ixod init [moniker] [flags]

Flags:
      --chain-id string   genesis file chain-id, if left blank will be randomly created
  -h, --help              help for init

```