### PR TITLE
Rework the Dockerfile so we install dependencies in the target image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1-buster
+FROM golang:1.19.4-buster
 
 ARG IXO_FOLDER
 ARG NETWORK

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4-alpine3.16
+FROM golang:1.19.1-buster
 
 ARG IXO_FOLDER
 ARG NETWORK
@@ -21,14 +21,11 @@ COPY ${IXO_FOLDER}/ /app
 COPY ${NETWORK}/genesis.json /ixo/genesis.json
 COPY entrypoint.sh /ixo/entrypoint.sh
 
-RUN apk update && \
-  apk upgrade && \
-  apk add --update alpine-sdk && \
-  apk add --no-cache bash git openssh make cmake && \
-  make install && \
-  apk del bash git openssh make cmake --quiet && \
-  mv /go/bin/ixod /usr/bin/ixod && \
-  adduser -H -u 1000 -g 1000 -D ixo
+# Add user to run the application
+# and create application directories for uploaded data and static data
+RUN adduser --disabled-password --gecos '' ixo
+
+RUN make install && mv /go/bin/ixod /usr/bin/ixod
 
 USER ixo
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IXO_ROOT		   ?= https://github.com/ixofoundation/ixo-blockchain
-IXO_RELEASE	   ?= v0.19.1
+IXO_RELEASE	   ?= v0.19.2
 IXO_DST_FOLDER ?= ixo-blockchain-${IXO_RELEASE}
 GOOS 					 ?= linux
 GOARCH				 ?= amd64
@@ -30,7 +30,7 @@ endif
 							 --build-arg NETWORK=$(network) \
 							 --build-arg IXO_RELEASE=$(IXO_RELEASE) \
 							 --build-arg BUILD_DATE=$(`date +'%y.%m.%d'`) \
-							 -t ixo:$(network)-${IXO_RELEASE} .
+							 -t gatewayfm/ixo:$(network)-${IXO_RELEASE} .
 
 clean:
 	rm -rf ${IXO_DST_FOLDER} bin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IXO_ROOT		   ?= https://github.com/ixofoundation/ixo-blockchain
-IXO_RELEASE	   ?= v0.18.1
+IXO_RELEASE	   ?= v0.19.1
 IXO_DST_FOLDER ?= ixo-blockchain-${IXO_RELEASE}
 GOOS 					 ?= linux
 GOARCH				 ?= amd64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IXO_ROOT		   ?= https://github.com/ixofoundation/ixo-blockchain
-IXO_RELEASE	   ?= v0.16.0
+IXO_RELEASE	   ?= v0.18.1
 IXO_DST_FOLDER ?= ixo-blockchain-${IXO_RELEASE}
 GOOS 					 ?= linux
 GOARCH				 ?= amd64

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-ixod: clone
 	-v "$(CURDIR)/bin:/go/bin/" \
 	-e GOARCH=${GOARCH} \
 	-e GOOS=${GOOS} \
-	--workdir "/app" golang:1.16 make install
+	--workdir "/app" golang:1.19.4-buster make install
 
 build-image: clone
 ifndef network

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -12,13 +12,19 @@ make build-image network=<network> # for example impacthub-3
 
 # Run ixod in docker
 
+1. Create a target folder where a volume will be mounted to
+
+```bash
+mkdir $(pwd)/.ixod
+```
+
 1. Start a container
 
-   ```
+   ```bash
     docker run -v $(pwd)/.ixod:/home/ixo/.ixod -p 26656:26656 -p 26657:26657 ixo:<network>-<release> start # ixo:pandora-4-v1.6.0
    ```
 
-1. The `ixo` folder will be created in the current directory
+1. The `ixo` folder will have the correct genesis and config files
 
 1. Update configuration according to the network related documentation
 
@@ -27,3 +33,6 @@ make build-image network=<network> # for example impacthub-3
    ```
 
 1. Run container one more time
+   ```bash
+    docker run -v $(pwd)/.ixod:/home/ixo/.ixod -p 26656:26656 -p 26657:26657 -d ixo:<network>-<release> start # ixo:pandora-4-v1.6.0
+   ```


### PR DESCRIPTION
Update documentation how to run a docker container.
This image is not very efficient in terms of size if you compare with the previous implementation.
71Mb vs 1.4Gb is not optimal however it is not clear yet how to make it smaller since
we are using a golang image, copying entire repo and installing all neded dependencies.